### PR TITLE
Allow google to index site

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -5,7 +5,6 @@ function MyApp({ Component, pageProps }) {
   return (
     <>
       <Head>
-        <meta name="robots" content="noindex, nofollow"/>
         <meta name="description" content="iOS Conf SG 2023, 12-13 January 2023" />
         <meta property="og:title" content="iOS Conf SG 2023, 12-13 January 2023" />
         <meta property="og:description" content="The largest iOS developer conference in Southeast Asia. Tickets are available for a limited time!" />


### PR DESCRIPTION
# Description

To allow google to index this website. 

Currently google search of site 2023.iosconf.sg return no results
![Screenshot 2022-12-21 at 1 04 47 AM](https://user-images.githubusercontent.com/1635805/208724340-ff748302-d74c-48b9-825f-117e24f60797.png)
